### PR TITLE
Remove console.log (requires a new build)

### DIFF
--- a/app/scripts/app.coffee
+++ b/app/scripts/app.coffee
@@ -34,8 +34,6 @@ angular.module('slick', [])
       vertical: "@"
     link: (scope, element, attrs) ->
 
-      console.log scope.responsive()
-
       $timeout(() ->
         slider = $(element)
         currentIndex = scope.currentIndex if scope.currentIndex?


### PR DESCRIPTION
Just installed it through [Rails assets](https://rails-assets.org/) and registered it there. After adding it I found out it contains a `console.log`. I don't think that's meant to be there?

It requires a new build to make sure it's not in the `dist` as well.
