### PR TITLE
Fix issue with ng-repeat where slick-list and .slick-track are missing

### DIFF
--- a/dist/slick.js
+++ b/dist/slick.js
@@ -47,7 +47,7 @@ angular.module('slick', []).directive('slick', [
           }
           apply();
           initializeSlick();
-        }
+        };
         initializeSlick = function () {
           return $timeout(function () {
             var currentIndex;


### PR DESCRIPTION
Modified the angular-slick.js wrapper only slightly by adding a slickApply method so that you can do dynamic updating of html with ng-repeat.

http://stackoverflow.com/questions/25087271/using-slick-caroussel-inside-a-template
