### PR TITLE
Introduced dynamic reloading of the carousel

### DIFF
--- a/app/scripts/app.coffee
+++ b/app/scripts/app.coffee
@@ -51,7 +51,13 @@ angular.module('slick', [])
       nextArrow:"@"
 
     link: (scope, element, attrs) ->
-
+      destroySlick = () ->
+        $timeout(() ->
+          slider = $(element)
+          slider.unslick()
+          slider.find('.slick-list').remove()
+          slider
+        )
       initializeSlick = () ->
         $timeout(() ->
           slider = $(element)
@@ -118,7 +124,10 @@ angular.module('slick', [])
       if scope.initOnload
         isInitialized = false
         scope.$watch("data", (newVal, oldVal) ->
-          if newVal? and not isInitialized
+          if newVal?
+            if isInitialized
+              destroySlick()
+ 
             initializeSlick()
             isInitialized = true
         )


### PR DESCRIPTION
Slick carousel was not able to refresh if its contents get changed. Now it can. If the valiable "data" changes, it gets destroyed and reloaded, just like it should in angular.

This commit is using the natural methods of slick-carousel, and is therefore better than #12 
