### PR TITLE
fix destroySlick() with new syntax

### DIFF
--- a/app/scripts/app.coffee
+++ b/app/scripts/app.coffee
@@ -54,7 +54,7 @@ angular.module('slick', [])
       destroySlick = () ->
         $timeout(() ->
           slider = $(element)
-          slider.unslick()
+          slider.slick('unslick')
           slider.find('.slick-list').remove()
           slider
         )


### PR DESCRIPTION
the new function-syntax was introduced with slick-carousel 1.4, and destroySlick() wasn't updated since