### PR TITLE
Handle all slick events

### DIFF
--- a/app/scripts/app.coffee
+++ b/app/scripts/app.coffee
@@ -114,6 +114,15 @@ angular.module('slick', [])
             if currentIndex?
               sl.slideHandler(currentIndex)
 
+          slider.on 'reInit', (sl) ->
+            scope.onReInit() if attrs.onReInit
+
+          slider.on 'setPosition', (sl) ->
+            scope.onSetPosition() if attrs.onSetPosition
+
+          slider.on 'swipe', (sl) ->
+            scope.onSwipe() if attrs.onSwipe
+
           slider.on 'afterChange', (event, slick, currentSlide, nextSlide) ->
             scope.onAfterChange() if scope.onAfterChange
 
@@ -122,6 +131,18 @@ angular.module('slick', [])
                 currentIndex = currentSlide
                 scope.currentIndex = currentSlide
               )
+
+          slider.on 'beforeChange', (sl) ->
+            scope.onBeforeChange() if attrs.onBeforeChange
+
+          slider.on 'breakpoint', (sl) ->
+            scope.onBreakpoint() if attrs.onBreakpoint
+
+          slider.on 'destroy', (sl) ->
+            scope.onDestroy() if attrs.onDestroy
+
+          slider.on 'edge', (sl) ->
+            scope.onEdge() if attrs.onEdge
 
           scope.$watch("currentIndex", (newVal, oldVal) ->
             if currentIndex? and newVal? and newVal != currentIndex


### PR DESCRIPTION
My use case was finding workaround for https://github.com/vasyabigi/angular-slick/issues/72.

Workaround was doing http://stackoverflow.com/questions/29101254/angularjs-slick-js-carousel-ng-click-not-firing-with-responsive-attribute-settin/30584787#30584787, but this worked only when resizing window, on mobile it still does not work. So I came up with `on-set-position="slickOnInit()"` which used to fix it, but I need onSetPosition support.

I added it as well as other events listed on https://github.com/kenwheeler/slick#events. It may be useful for many other use cases to have this events available.

@vasyabigi Please review and merge it as soon as you have time. Would be nice if you can release new version including this change.

Thanks.
