### PR TITLE
InitialSlide option is now working

### DIFF
--- a/dist/slick.js
+++ b/dist/slick.js
@@ -94,7 +94,7 @@ angular.module('slick', []).directive('slick', [
               fade: scope.fade === 'true',
               focusOnSelect: scope.focusOnSelect === 'true',
               infinite: scope.infinite !== 'false',
-              initialSlide: scope.initialSlide || 0,
+              initialSlide: scope.initialSlide != null ? parseInt(scope.initialSlide, 10) : 0,
               lazyLoad: scope.lazyLoad || 'ondemand',
               beforeChange: attrs.onBeforeChange ? scope.onBeforeChange : void 0,
               onReInit: attrs.onReInit ? scope.onReInit : void 0,


### PR DESCRIPTION
The initial slide option was not working and whenever I tried to use it, it broke the carousel completely. With this change you can now use it.
