### PR TITLE
Add mobile first property to directive attributes

### DIFF
--- a/app/scripts/app.coffee
+++ b/app/scripts/app.coffee
@@ -35,6 +35,7 @@ angular.module('slick', [])
       pauseOnHover: "@"
       pauseOnDotsHover: "@"
       responsive: "="
+      mobileFirst: "@"
       rtl: "@"
       slide: "@"
       slidesToShow: "@"
@@ -93,6 +94,7 @@ angular.module('slick', [])
             onSetPosition: if attrs.onSetPosition then scope.onSetPosition else undefined
             pauseOnHover: scope.pauseOnHover isnt "false"
             responsive: scope.responsive or undefined
+            mobileFirst: scope.mobileFirst is "true"
             rtl: scope.rtl is "true"
             slide: scope.slide or "div"
             slidesToShow: if scope.slidesToShow? then parseInt(scope.slidesToShow, 10) else 1


### PR DESCRIPTION
Responsive settings use mobile first calculation.

``` html
<slick mobile-first="true" responsive="responsiveSettings">
  ...
</slick>
```

``` javascript
$scope.responsiveSettings = [{
  breakpoint: 300, 
  settings: {
    slidesToShow: 2
  }
},{
  breakpoint: 780,
  settings: 'unslick'
}];
```
